### PR TITLE
Feat: Introduce support PHP `^8.1` and `^6.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
+- [BC]: Drop support Symfony `3.4` and not LTS versions `4.x` and `5.x`
+- Feat: Introduce support PHP `^8.1` and `^6.1`
 - Feat: Introduce more similar JSX variables syntax
 - Chore: Fix remove unnecessary configuration parameter `css_class_prefix`
 - Chore: Fix typo in Makefile command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
 - Feat: Introduce more similar JSX variables syntax
+- Chore: Fix remove unnecessary configuration parameter `css_class_prefix`
 - Chore: Fix typo in Makefile command
 - Chore: Fix ecs-fix command in Makefile
 - Update `lmc/coding-standard` package to version `3.3`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
+- Feat: Introduce more similar JSX variables syntax
 - Chore: Fix typo in Makefile command
+- Chore: Fix ecs-fix command in Makefile
+- Update `lmc/coding-standard` package to version `3.3`
+
 
 ## 2.1.0 - 2022-07-28
 - Feat: Enable glob function patterns in a paths (refs #4)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ecs: ## Run composer ecs
 	@$(COMPOSER) ecs
 
 ecs-fix: ## Run composer ecs-fix
-	@$(COMPOSER) ecs-fix
+	@$(COMPOSER) ecs:fix
 
 test: ## Run composer tests
 	@$(COMPOSER) tests

--- a/README.md
+++ b/README.md
@@ -48,8 +48,7 @@ If you want to change the default settings, create a config
         # define one or more paths to expand or overload components (uses glob patterns)
         paths: 
             - "%kernel.project_dir%/templates/components"
-        paths_alias: 'jobs-ui' # default is 'spirit'
-        css_class_prefix: 'jobs' # default is null
+        paths_alias: 'jobs-ui' # alias for twig paths above (default is 'spirit')
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ TwigX Bundle
 This is a Symfony bundle with Twig implementation of [Spirit Design System] components, extended with HTML-like syntax.
 
 ## Requirements
-- PHP 7.4
-- Symfony 3.4+ || 4.2+ || 5.0+
+- PHP 7.4 || 8.1
+- Symfony 3.4+ || 4.4+ || 5.4+ || ^6.1
 - Twig >=1.44.6 || >=2.12.5 || 3+
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ other="{{'this' ~ 'works' ~ 'too'}}"
 anotherProp="or this still work"
 not-this="{{'this' ~ 'does'}}{{ 'not work' }}" // this returns syntax as plain text but prop with dash work
 ifCondition="{{ variable == 'success' ? 'true' : 'false' }}"  // condition can only be written via the ternary operator
+jsXCondition={ variable == 'success' ? 'true' : 'false' }  // condition can only be written via the ternary operator
+isBoolean={false}  // if value is false
+numberValue={11}  // if value is number 11
 isOpen  // if no value is defined, it is set to true
 >
     Submit

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "phpunit/phpunit": "^9",
     "mockery/mockery": "^1.5",
     "doctrine/cache": "^1.10",
-    "lmc/coding-standard": "^3.2",
+    "lmc/coding-standard": "^3.3",
     "symfony/yaml": "^3.4 || ^4.2 || ^5.0",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-mockery": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,13 @@
     }
   },
   "require": {
-    "php": "^7.4",
-    "symfony/config": "^3.4 ||^4.2 || ^5.0",
-    "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
-    "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
-    "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+    "php": "^7.4 || ^8.1",
+    "symfony/config": "^4.4 || ^5.4 || ^6.1",
+    "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.1",
+    "symfony/http-foundation": "^4.4 || ^5.4 || ^6.1",
+    "symfony/http-kernel": "^4.4 || ^5.4 || ^6.1",
     "symfony/polyfill-php80": "^1.23",
+    "symfony/polyfill-php81": "^1.26",
     "twig/twig": "^1.44.6 || ^2.12.5 || ^3.0.0",
     "ext-simplexml": "*"
   },
@@ -34,7 +35,7 @@
     "mockery/mockery": "^1.5",
     "doctrine/cache": "^1.10",
     "lmc/coding-standard": "^3.3",
-    "symfony/yaml": "^3.4 || ^4.2 || ^5.0",
+    "symfony/yaml": "^4.4 || ^5.4 || ^6.1 ",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-mockery": "^1.0",
     "phpstan/extension-installer": "^1.1",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:8.1
 
 # Install unzip utility and libs needed by zip PHP extension
 RUN apt-get update && apt-get install -y \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,12 @@
 FROM php:7.4
 
+# Install unzip utility and libs needed by zip PHP extension
+RUN apt-get update && apt-get install -y \
+    zlib1g-dev \
+    libzip-dev \
+    unzip
+RUN docker-php-ext-install zip
+
 # copy files
 COPY ./install-composer.sh /tmp
 

--- a/src/DependencyInjection/CompilerPass/OverrideServiceCompilerPass.php
+++ b/src/DependencyInjection/CompilerPass/OverrideServiceCompilerPass.php
@@ -13,8 +13,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class OverrideServiceCompilerPass implements CompilerPassInterface
 {
-    public const GLOBAL_PREFIX_TWIG_VARIABLE = '_twigxClassPrefix';
-
     public function process(ContainerBuilder $container): void
     {
         $twigDefinition = $container->getDefinition('twig');
@@ -24,7 +22,6 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
         /** @var array<string> $paths */
         $paths = $container->getParameter(TwigXExtension::PARAMETER_PATHS);
         $pathAlias = $container->getParameter(TwigXExtension::PARAMETER_PATH_ALIAS);
-        $classPrefix = $container->getParameter(TwigXExtension::PARAMETER_CSS_CLASS_PREFIX);
 
         $this->addGlobPath($twigLoaderDefinition, TwigXExtension::DEFAULT_PARTIALS_PATH, TwigXExtension::DEFAULT_PARTIALS_ALIAS);
 
@@ -35,8 +32,6 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
                 $this->addGlobPath($twigLoaderDefinition, $path, TwigXExtension::DEFAULT_PATH_ALIAS);
             }
         }
-
-        $twigDefinition->addMethodCall('addGlobal', [self::GLOBAL_PREFIX_TWIG_VARIABLE, $classPrefix]);
 
         $twigDefinition->addMethodCall('setLexer', [new Reference(ComponentLexer::class)]);
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -28,9 +28,6 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('paths_alias')
             ->defaultValue(TwigXExtension::DEFAULT_PATH_ALIAS)
             ->end()
-            ->scalarNode('css_class_prefix')
-            ->defaultNull()
-            ->end()
             ->end()
             ->end();
 

--- a/src/DependencyInjection/TwigXExtension.php
+++ b/src/DependencyInjection/TwigXExtension.php
@@ -18,8 +18,6 @@ class TwigXExtension extends Extension
 {
     public const PARAMETER_PATHS = 'twigx.paths';
 
-    public const PARAMETER_CSS_CLASS_PREFIX = 'twigx.css_class_prefix';
-
     public const PARAMETER_PATH_ALIAS = 'twigx.paths_alias';
 
     public const DEFAULT_COMPONENTS_PATH = __DIR__ . '';
@@ -39,7 +37,6 @@ class TwigXExtension extends Extension
         $loader->load('services.yml');
 
         $container->setParameter(self::PARAMETER_PATHS, array_merge($config['paths'], [self::DEFAULT_COMPONENTS_PATH]));
-        $container->setParameter(self::PARAMETER_CSS_CLASS_PREFIX, isset($config['css_class_prefix']) ? $config['css_class_prefix'] . '-' : null);
         $container->setParameter(self::PARAMETER_PATH_ALIAS, $config['paths_alias']);
     }
 }

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lmc\TwigXBundle\Compiler;
+
+use PHPUnit\Framework\TestCase;
+
+class ComponentTagCompilerTest extends TestCase
+{
+    public function testShouldCompile(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert color="primary" />', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'color\': "primary"} } %}{% endembed %}', $compiler->compile());
+    }
+
+    public function testShouldCompileTwigAttributeJSXSyntax(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert number={12} value={ aaa } isBool={false} />', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'number\': 12,\'value\': aaa,\'isBool\': false} } %}{% endembed %}', $compiler->compile());
+    }
+
+    public function testShouldCompileTwigConditions(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert number={ true ? 12 : 10 } />', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'number\': true ? 12 : 10} } %}{% endembed %}', $compiler->compile());
+    }
+}

--- a/tests/DependencyInjection/CompilerPass/OverrideServiceCompilerPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/OverrideServiceCompilerPassTest.php
@@ -41,7 +41,6 @@ class OverrideServiceCompilerPassTest extends TestCase
     {
         $this->builder->setParameter('twigx.paths', $paths);
         $this->builder->setParameter('twigx.paths_alias', 'test');
-        $this->builder->setParameter('twigx.css_class_prefix', null);
         $this->overrideService->process($this->builder);
 
         $filteredAddPathCalls = DefinitionHelper::getMethodCalls(
@@ -77,7 +76,6 @@ class OverrideServiceCompilerPassTest extends TestCase
     {
         $this->builder->setParameter('twigx.paths', []);
         $this->builder->setParameter('twigx.paths_alias', 'test');
-        $this->builder->setParameter('twigx.css_class_prefix', null);
         $this->overrideService->process($this->builder);
 
         $filteredAddGlobal = DefinitionHelper::getMethodCalls(
@@ -90,6 +88,6 @@ class OverrideServiceCompilerPassTest extends TestCase
             'setLexer',
         );
 
-        $this->assertSame(2, count($filteredAddGlobal) + count($filteredAddLexer));
+        $this->assertSame(1, count($filteredAddGlobal) + count($filteredAddLexer));
     }
 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -16,7 +16,6 @@ class ConfigurationTest extends TestCase
 twigx:
     paths:                []
     paths_alias:          spirit
-    css_class_prefix:     null
 
 CONFIG;
 

--- a/tests/DependencyInjection/TwigXExtensionTest.php
+++ b/tests/DependencyInjection/TwigXExtensionTest.php
@@ -35,32 +35,5 @@ class TwigXExtensionTest extends TestCase
 
         $this->assertTrue($this->containerBuilder->hasParameter('twigx.paths'));
         $this->assertTrue($this->containerBuilder->hasParameter('twigx.paths_alias'));
-        $this->assertTrue($this->containerBuilder->hasParameter('twigx.css_class_prefix'));
-    }
-
-    /**
-     * @param array<string, string> $configuration
-     * @dataProvider spiritClassPrefixParameterDataProvider
-     */
-    public function testShouldGetSpiritClassPrefixParameter(array $configuration, ?string $expectedValue): void
-    {
-        $this->loadExtension([$configuration]);
-
-        $this->assertEquals($expectedValue, $this->containerBuilder->getParameter('twigx.css_class_prefix'));
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    public function spiritClassPrefixParameterDataProvider(): array
-    {
-        return [
-            'default value' => [[], null],
-            'custom value' => [
-                [
-                    'css_class_prefix' => 'jobs',
-                ], 'jobs-',
-            ],
-        ];
     }
 }


### PR DESCRIPTION
- Also includes [BC]: Drop support Symfony `3.4` and not LTS versions `4.x` and `5.x`