### PR TITLE
BC: Introduce support PHP `^8.1` and `^6.1` & drop Symfony old versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
+- [BC]: Drop support Symfony `3.4` and not LTS versions `4.x` and `5.x`
+- Feat: Introduce support PHP `^8.1` and `^6.1`
 - Feat: Introduce more similar JSX variables syntax
 - Chore: Fix remove unnecessary configuration parameter `css_class_prefix`
 - Chore: Fix typo in Makefile command

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ TwigX Bundle
 This is a Symfony bundle with Twig implementation of [Spirit Design System] components, extended with HTML-like syntax.
 
 ## Requirements
-- PHP 7.4
-- Symfony 3.4+ || 4.2+ || 5.0+
+- PHP 7.4 || 8.1
+- Symfony 3.4+ || 4.4+ || 5.4+ || ^6.1
 - Twig >=1.44.6 || >=2.12.5 || 3+
 
 ## Changelog

--- a/composer.json
+++ b/composer.json
@@ -20,12 +20,13 @@
     }
   },
   "require": {
-    "php": "^7.4",
-    "symfony/config": "^3.4 ||^4.2 || ^5.0",
-    "symfony/dependency-injection": "^3.4 || ^4.2 || ^5.0",
-    "symfony/http-foundation": "^3.4 || ^4.2 || ^5.0",
-    "symfony/http-kernel": "^3.4 || ^4.2 || ^5.0",
+    "php": "^7.4 || ^8.1",
+    "symfony/config": "^4.4 || ^5.4 || ^6.1",
+    "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.1",
+    "symfony/http-foundation": "^4.4 || ^5.4 || ^6.1",
+    "symfony/http-kernel": "^4.4 || ^5.4 || ^6.1",
     "symfony/polyfill-php80": "^1.23",
+    "symfony/polyfill-php81": "^1.26",
     "twig/twig": "^1.44.6 || ^2.12.5 || ^3.0.0",
     "ext-simplexml": "*"
   },
@@ -34,7 +35,7 @@
     "mockery/mockery": "^1.5",
     "doctrine/cache": "^1.10",
     "lmc/coding-standard": "^3.3",
-    "symfony/yaml": "^3.4 || ^4.2 || ^5.0",
+    "symfony/yaml": "^4.4 || ^5.4 || ^6.1",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-mockery": "^1.0",
     "phpstan/extension-installer": "^1.1",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4
+FROM php:8.1
 
 # Install unzip utility and libs needed by zip PHP extension
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
- also include [BC] Drop support Symfony `3.4` and not LTS versions `4.x` and `5.x`