### PR TITLE
Fix/remove comments in props

### DIFF
--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -102,35 +102,35 @@ class ComponentTagCompiler
         $pattern = "/
             <
                 \s*
-                ([[A-Z]\w+]*)
-                (?<attributes>
-                    (?:
-                        \s+
-                        (?:
-                            (?:
-                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
-                            )
+                ([[A-Z]\w+]*)                                            # First capturing group - component name
+                (?<attributes>                                           # Named capturing group - attributes
+                    (?:                                                  # Non-capturing group
+                        \s+                                              # Matches zero or more whitespace character
+                        (?:                                              # Non-capturing group
+                            (?:                                          # Non-capturing group
+                                \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}  # Matches attributes between {{ and }}
+                            )                                            # End of non-capturing group
                             |                                            # or
                             (?:\{\#.*\#\})                               # Matches Twig comments, non-capturing
                             |                                            # or
-                            (?:
-                                [\w\-:.@]+
-                                (
-                                    =
-                                    (?:
-                                        \\\"[^\\\"]*\\\"
-                                        |
-                                        \'[^\']*\'
-                                        |
-                                        [^\'\\\"=<>]+
-                                    )
-                                )?
-                            )
-                        )
-                    )*
-                    \s*
-                )
-            \/>
+                            (?:                                          # Non-capturing group
+                                [\w\-:.@]+                               # Matches list of one or more words and characters -:.@ literally
+                                (                                        # Third capturing group
+                                    =                                    # Matches the character =
+                                    (?:                                  # Non-capturing group
+                                        \\\"[^\\\"]*\\\"                 # Matches list of characters
+                                        |                                # or
+                                        \'[^\']*\'                       # Matches list of characters
+                                        |                                # or
+                                        [^\'\\\"=<>]+                    # Matches list of characters
+                                    )                                    # End of non-capturing group
+                                )?                                       # Matches group zero or one time
+                            )                                            # End of non-capturing group
+                        )                                                # End of non-capturing group
+                    )*                                                   # End of non-capturing group
+                    \s*                                                  # Matches whitespace character zero or more
+                )                                                        # End of non-capturing group
+            \/>                                                          # Matches string literally
         /x";
 
         return (string) preg_replace_callback(

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -46,6 +46,8 @@ class ComponentTagCompiler
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
+                            (?!\#\}).+?                                 # Use negative lookahead to match until the first occurrence of #}
+                            |
                             (?:
                                 [\w\-:.@]+
                                 (
@@ -108,7 +110,9 @@ class ComponentTagCompiler
                             (?:
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
-                            |
+                            |                                            # or
+                            (?:\{\#.*\#\})                               # Matches Twig comments, non-capturing
+                            |                                            # or
                             (?:
                                 [\w\-:.@]+
                                 (

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -172,6 +172,7 @@ class ComponentTagCompiler
     protected function getAttributesFromAttributeString(string $attributeString): string
     {
         $attributeString = $this->parseAttributeBag($attributeString);
+        $attributeString = $this->pourOutCommentsFromAttributeBag($attributeString);
 
         $pattern = '/
             (?<attribute>[\w\-:.@]+)
@@ -239,5 +240,23 @@ class ComponentTagCompiler
         /x";
 
         return (string) preg_replace($pattern, ' :attributes="$1"', $attributeString);
+    }
+
+    /**
+     * Remove Twig comments from given attribute string
+     */
+    protected function pourOutCommentsFromAttributeBag(string $attributeString): string
+    {
+        $pattern = "/
+            (                                               # First capturing group
+                \{\#                                        # Match {# literally
+                    (                                       # Second capturing group
+                        (?!\#\}).+?                         # Use negative lookahead to match until the first occurrence of #}
+                    )                                       # End of second capturing group
+                \#\}                                        # Match #} literally
+            )                                               # End of first capturing group
+        /x";
+
+        return (string) preg_replace($pattern, '', $attributeString);
     }
 }

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -22,6 +22,20 @@ class ComponentTagCompilerTest extends TestCase
         $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}', $compiler->compile());
     }
 
+    public function testShouldCompileTwigVariablesWithTwigCommentSelfClosingTag(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}} />', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}', $compiler->compile());
+    }
+
+    public function testShouldCompileTwigVariablesWithTwigComment(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}}>Test</Alert>', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}', $compiler->compile());
+    }
+
     public function testShouldCompileTwigAttributeJSXSyntax(): void
     {
         $compiler = new ComponentTagCompiler('<Alert number={12} value={ aaa } isBool={false} />', 'alias');

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -22,20 +22,6 @@ class ComponentTagCompilerTest extends TestCase
         $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}', $compiler->compile());
     }
 
-    public function testShouldCompileTwigVariablesWithTwigCommentSelfClosingTag(): void
-    {
-        $compiler = new ComponentTagCompiler('<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}} />', 'alias');
-
-        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}', $compiler->compile());
-    }
-
-    public function testShouldCompileTwigVariablesWithTwigComment(): void
-    {
-        $compiler = new ComponentTagCompiler('<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}}>Test</Alert>', 'alias');
-
-        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}', $compiler->compile());
-    }
-
     public function testShouldCompileTwigAttributeJSXSyntax(): void
     {
         $compiler = new ComponentTagCompiler('<Alert number={12} value={ aaa } isBool={false} />', 'alias');
@@ -48,5 +34,57 @@ class ComponentTagCompilerTest extends TestCase
         $compiler = new ComponentTagCompiler('<Alert number={ true ? 12 : 10 } />', 'alias');
 
         $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'number\': true ? 12 : 10} } %}{% endembed %}', $compiler->compile());
+    }
+
+    /**
+     * @dataProvider twigCommentsDataProvider
+     */
+    public function testShouldCompileTwigVariablesWithTwigComment(string $component, string $expected): void
+    {
+        $compiler = new ComponentTagCompiler($component, 'alias');
+
+        $this->assertSame($expected, $compiler->compile());
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function twigCommentsDataProvider(): array
+    {
+        return [
+            // component, expected
+            'comment in self-closing component' => [
+                '<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}} />',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'multiple comments in self-closing component' => [
+                '<Alert {# This is comment #} variable="{{value}}" {# This is second comment #} variableWithoutQuotes={{value}} />',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'comment in pair component' => [
+                '<Alert variable="{{value}}" {# This is comment #} variableWithoutQuotes={{value}}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+            'multiple comments in pair component' => [
+                '<Alert {# This is comment #} variable="{{value}}" {# This is second comment #} variableWithoutQuotes={{value}}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+            'comment out prop in self-closing component' => [
+                '<Alert {# variable="{{value}}" #} variableWithoutQuotes={{value}} />',
+                '{% embed "@alias/alert.twig" with { props: {\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'comment out prop in pair component' => [
+                '<Alert {# variable="{{value}}" #} variableWithoutQuotes={{value}}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+            'empty comment in self-closing component' => [
+                '<Alert variable="{{value}}" {# #} variableWithoutQuotes={{value}} />',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'empty comment in pair component' => [
+                '<Alert variable="{{value}}" {#  #} variableWithoutQuotes={{value}}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Allow Twig comments `{# This is comment #}` to be placed between component props.

You can test it at https://regex101.com/r/3QA0Fl/1