### PR TITLE
Fixing allowed parenthesis used in passing props

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ or pure original implementation
 {% endembed %}
 ```
 
+### Allowed parenthesis
+
+You can pass variables to props using two syntaxes.
+JSX-like syntax uses single `{...}` parentheses or Twig-like syntax that uses `{{...}}` parentheses.
+In both cases, there can be a whitespace around the value that is used.
+See the examples below.
+
+JSX-like syntax example:
+
+```html
+<ComponentName variable={value} anotherVariable={ value } />
+```
+
+Twig like syntax example:
+
+```html
+<ComponentName variable={{value}} anotherVariable={{ value }} />
+```
+
 if you want to extend these components, an example guide is [here](./docs/extendComponents.md).
 if you want to contribute, read guide [here](./docs/contribution.md).
 

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -156,12 +156,18 @@ class ComponentTagCompiler
             return $this->stripQuotes($value);
         }
 
-        $valueWithoutQuotes = $this->stripQuotes($value);
+        // `"{{ value }} "` -> `{{ value }}`
+        // `"{ value } "` -> `{ value }`
+        // `"{{value}} "` -> `{{value}}`
+        // `"{value} "` -> `{value}`
+        $valueWithoutQuotes = trim($this->stripQuotes($value));
 
+        // `{{ value }}` or `{{value}}`
         if (\str_starts_with($valueWithoutQuotes, '{{') && (mb_strpos($valueWithoutQuotes, '}}') === mb_strlen($valueWithoutQuotes) - 2)) {
-            return mb_substr($valueWithoutQuotes, 2, -2);
+            return trim(mb_substr($valueWithoutQuotes, 2, -2));
         }
 
+        // `{ value }` or `{value}`
         if (\str_starts_with($valueWithoutQuotes, '{') && (mb_strpos($valueWithoutQuotes, '}') === mb_strlen($valueWithoutQuotes) - 1)) {
             return trim(mb_substr($valueWithoutQuotes, 1, -1));
         }
@@ -180,13 +186,13 @@ class ComponentTagCompiler
                 =
                 (?<value>
                     (
-                        \"[^\"]+\"
-                        |
-                        \\\'[^\\\']+\\\'
-                        |
-                        \{[^\{]+\}
-                        |
-                        [^\s>]+
+                        \"[^\"]+\"       # Capture all that is between "..." but not `"`
+                        |                # or
+                        \\\'[^\\\']+\\\' # Capture all that is between \'...\' but not `\'`
+                        |                # or
+                        \{[^\{]+\}       # Capture all that is between {...} but not `{`
+                        |                # or
+                        [^>]+            # Capture any character but not `>`
                     )
                 )
             )?

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -46,7 +46,7 @@ class ComponentTagCompiler
                                 \{\{\s*\\\$attributes(?:[^}]+?)?\s*\}\}
                             )
                             |
-                            (?!\#\}).+?                                 # Use negative lookahead to match until the first occurrence of #}
+                            (\{\#\s*(.*?)\s*\#\})                        # Capture any sequence between {# and #}
                             |
                             (?:
                                 [\w\-:.@]+
@@ -91,6 +91,7 @@ class ComponentTagCompiler
      */
     protected function compileClosingTags(string $value): string
     {
+        // replace </Alert> with {% endblock %}{% endembed %}
         return (string) preg_replace("/<\/\s*([[A-Z]\w+]*)\s*>/", '{% endblock %}{% endembed %}', $value);
     }
 

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -15,6 +15,20 @@ class ComponentTagCompilerTest extends TestCase
         $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'color\': "primary"} } %}{% endembed %}', $compiler->compile());
     }
 
+    public function testShouldCompileClosingTag(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert color="primary">test</Alert>', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'color\': "primary"} } %}{% block content %}test{% endblock %}{% endembed %}', $compiler->compile());
+    }
+
+    public function testShouldCompileClosingTagWithWhitespace(): void
+    {
+        $compiler = new ComponentTagCompiler('<Alert color="primary"  >test</Alert>', 'alias');
+
+        $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'color\': "primary"} } %}{% block content %}test{% endblock %}{% endembed %}', $compiler->compile());
+    }
+
     public function testShouldCompileTwigVariables(): void
     {
         $compiler = new ComponentTagCompiler('<Alert variable="{{value}}" variableWithoutQuotes={{value}} />', 'alias');

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -37,6 +37,42 @@ class ComponentTagCompilerTest extends TestCase
     }
 
     /**
+     * @dataProvider twigParenthesesDataProvider
+     */
+    public function testShouldCompileTwigVariablesParentheses(string $component, string $expected): void
+    {
+        $compiler = new ComponentTagCompiler($component, 'alias');
+
+        $this->assertSame($expected, $compiler->compile());
+    }
+
+    /**
+     * @return array<string, string[]>
+     */
+    public function twigParenthesesDataProvider(): array
+    {
+        return [
+            // component, expected
+            'jsx syntax parentheses' => [
+                '<Alert variable="{value}" variableWithoutQuotes={value} />',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'jsx syntax parentheses with spaces' => [
+                '<Alert variable="{ value }" variableWithoutQuotes={ value } />',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% endembed %}',
+            ],
+            'twig syntax parentheses' => [
+                '<Alert variable="{{value}}" variableWithoutQuotes={{value}}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+            'twig syntax parentheses with spaces' => [
+                '<Alert variable="{{ value }}" variableWithoutQuotes={{ value }}>Test</Alert>',
+                '{% embed "@alias/alert.twig" with { props: {\'variable\': value,\'variableWithoutQuotes\': value} } %}{% block content %}Test{% endblock %}{% endembed %}',
+            ],
+        ];
+    }
+
+    /**
      * @dataProvider twigCommentsDataProvider
      */
     public function testShouldCompileTwigVariablesWithTwigComment(string $component, string $expected): void


### PR DESCRIPTION
Before:
✅ `{value}`
✅ `{{value}}`
✅ `{ value }`
❌ `{{ value }}`

After:
✅ `{value}`
✅ `{{value}}`
✅ `{ value }`
✅ `{{ value }}`