### PR TITLE
Feat: Normalize template name using regex to allow capitalized prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 <!-- There should always be "Unreleased" section at the beginning. -->
 ## Unreleased
+- Feat: Normalize template name using regex to allow capitalized prefixes
 
 ## 3.2.1 - 2023-03-30
 - Fix: Negative lookahead breaks parsing of element closing bracket

--- a/src/Compiler/ComponentTagCompiler.php
+++ b/src/Compiler/ComponentTagCompiler.php
@@ -83,7 +83,13 @@ class ComponentTagCompiler
 
     protected function componentStartString(string $component, string $attributes): string
     {
-        return "{% embed \"@" . $this->twigPathAlias . "/" . lcfirst($component) . ".twig\" with { props: $attributes } %}";
+        return sprintf(
+            // another `%` is used for escaping the `%`, e. g. `%%` -> `%`
+            "{%% embed \"@%s/%s.twig\" with { props: %s } %%}",
+            $this->twigPathAlias,
+            $this->normalizeComponentPathName($component),
+            $attributes
+        );
     }
 
     /**
@@ -144,6 +150,13 @@ class ComponentTagCompiler
             },
             $value
         );
+    }
+
+    private function normalizeComponentPathName(string $name): string
+    {
+        return preg_replace_callback('/^[A-Z]+_?/', function ($matches) {
+            return strtolower($matches[0]);
+        }, $name) ?: $name;
     }
 
     private function valueParser(?string $value, string $attribute): string

--- a/tests/Compiler/ComponentTagCompilerTest.php
+++ b/tests/Compiler/ComponentTagCompilerTest.php
@@ -15,6 +15,13 @@ class ComponentTagCompilerTest extends TestCase
         $this->assertSame('{% embed "@alias/alert.twig" with { props: {\'color\': "primary"} } %}{% endembed %}', $compiler->compile());
     }
 
+    public function testShouldCompileUnstable(): void
+    {
+        $compiler = new ComponentTagCompiler('<UNSTABLE_Alert color="primary" />', 'alias');
+
+        $this->assertSame('{% embed "@alias/unstable_Alert.twig" with { props: {\'color\': "primary"} } %}{% endembed %}', $compiler->compile());
+    }
+
     public function testShouldCompileClosingTag(): void
     {
         $compiler = new ComponentTagCompiler('<Alert color="primary">test</Alert>', 'alias');


### PR DESCRIPTION
  * prefixes in the format `PREFIX_` for template name can now be used
  * it will normalize the template name to lowercase - `prefix_`
  * motivation is to allow `UNSTABLE_` prefix name for our components